### PR TITLE
Update IR_TX Samsung32 Address Format

### DIFF
--- a/ir_tx/nec.py
+++ b/ir_tx/nec.py
@@ -27,7 +27,10 @@ class NEC(IR):
         else:
             self.append(9000, 4500)
         if addr < 256:  # Short address: append complement
-            addr |= ((addr ^ 0xff) << 8)
+            if self.samsung:
+              addr |= addr << 8
+            else:
+              addr |= ((addr ^ 0xff) << 8)
         for _ in range(16):
             self._bit(addr & 1)
             addr >>= 1


### PR DESCRIPTION
Builds different [addr] formats for the NEC or Samsung32 protocol.
- NEC: 8 address bits + 8 inverted address bits
- Samsung32: 8 address bits + 8 address bits

This is based on the logic found in the FlipperZero IR Samsung Encoder: https://github.com/flipperdevices/flipperzero-firmware/blob/052237f8c9bb34bc244abcbf108cdf1ec6ec58ec/lib/infrared/encoder_decoder/samsung/infrared_encoder_samsung.c#L27-L31