### PR TITLE
Remove hard coding of asize in Player

### DIFF
--- a/ir_tx/__init__.py
+++ b/ir_tx/__init__.py
@@ -136,8 +136,8 @@ class IR:
 # Given an iterable (e.g. list or tuple) of times, emit it as an IR stream.
 class Player(IR):
 
-    def __init__(self, pin, freq=38000, verbose=False):  # NEC specifies 38KHz
-        super().__init__(pin, freq, 68, 33, verbose)  # Measured duty ratio 33%
+    def __init__(self, pin, freq=38000, verbose=False, asize=68):  # NEC specifies 38KHz
+        super().__init__(pin, freq, asize, 33, verbose)  # Measured duty ratio 33%
 
     def play(self, lst):
         for x, t in enumerate(lst):


### PR DESCRIPTION
Currently it is not possible to change the length of bursts when using the player class, hard coded to 68.

This PR exposes optional asize param.