### PR TITLE
Update rp2_rmt to use hard interrupts

### DIFF
--- a/ir_tx/rp2_rmt.py
+++ b/ir_tx/rp2_rmt.py
@@ -56,7 +56,7 @@ class RP2_RMT:
         self.ict = None  # Current IRQ count
         self.icm = 0  # End IRQ count
         self.reps = 0  # 0 == forever n == no. of reps
-        rp2.PIO(0).irq(self._cb)
+        rp2.PIO(0).irq(handler=self._cb, hard=True)
 
     # IRQ callback. Because of FIFO IRQ's keep arriving after STOP.
     def _cb(self, pio):


### PR DESCRIPTION
Update irqs to hard.
Fix for issue #40 and #28