### PR TITLE
Return protocol detected with ir_rx/acquire.py acquire function

### DIFF
--- a/RECEIVER.md
+++ b/RECEIVER.md
@@ -64,7 +64,9 @@ This script waits for a single burst from the remote and prints the timing of
 the pulses followed by its best guess at the protocol. It correctly identifies
 supported protocols, but can wrongly identify unsupported protocols. The
 report produced by the script exposed to an unknown protocol is unpredictable.
-The `test()` function returns a list of the mark and space periods (in μs).
+The `test()` function returns a dictionary containing two keys, `raw` and
+`protocol`. `raw` is a list of the mark and space periods (in μs). `protocol`
+is the protocl as a string
 
 # 3. The driver
 

--- a/TRANSMITTER.md
+++ b/TRANSMITTER.md
@@ -341,7 +341,7 @@ import ujson
 
 lst = test()  # May report unsupported or unknown protocol
 with open('burst.py', 'w') as f:
-    ujson.dump(lst, f)
+    ujson.dump(lst['raw'], f)
 ```
 This replays it:  
 ```python

--- a/ir_rx/acquire.py
+++ b/ir_rx/acquire.py
@@ -17,6 +17,7 @@ class IR_GET(IR_RX):
         self.display = display
         super().__init__(pin, nedges, twait, lambda *_ : None)
         self.data = None
+        self.protocol = None
 
     def decode(self, _):
         def near(v, target):
@@ -33,55 +34,62 @@ class IR_GET(IR_RX):
         lb = len(burst)  # Actual length
         # Duration of pulse train 24892 for RC-5 22205 for RC-6
         duration = ticks_diff(self._times[lb - 1], self._times[0])
+    
+        for x, e in enumerate(burst):
+            if self.display: print('{:03d} {:5d}'.format(x, e))
+        if self.display: print()
+        # Attempt to determine protocol
+        ok = False  # Protocol not yet found
+        if near(burst[0], 9000) and lb == 67:
+            if self.display: print('NEC')
+            self.protocol = 'NEC'
+            ok = True
 
-        if self.display:
-            for x, e in enumerate(burst):
-                print('{:03d} {:5d}'.format(x, e))
-            print()
-            # Attempt to determine protocol
-            ok = False  # Protocol not yet found
-            if near(burst[0], 9000) and lb == 67:
-                print('NEC')
+        if not ok and near(burst[0], 2400) and near(burst[1], 600):  # Maybe Sony
+            try:
+                nbits = {25:12, 31:15, 41:20}[lb]
+            except KeyError:
+                pass
+            else:
+                ok = True
+                self.protocol = 'Sony'
+                if self.display: print('Sony {}bit'.format(nbits))
+
+        if not ok and near(burst[0], 889):  # Maybe RC-5
+            if near(duration, 24892) and near(max(burst), 1778):
+                self.protocol = 'RC-5'
+                if self.display: print('Philps RC-5')
                 ok = True
 
-            if not ok and near(burst[0], 2400) and near(burst[1], 600):  # Maybe Sony
-                try:
-                    nbits = {25:12, 31:15, 41:20}[lb]
-                except KeyError:
-                    pass
-                else:
-                    ok = True
-                    print('Sony {}bit'.format(nbits))
-
-            if not ok and near(burst[0], 889):  # Maybe RC-5
-                if near(duration, 24892) and near(max(burst), 1778):
-                    print('Philps RC-5')
-                    ok = True
-
-            if not ok and near(burst[0], 2666) and near(burst[1], 889):  # RC-6?
-                if near(duration, 22205) and near(burst[1], 889) and near(burst[2], 444):
-                    print('Philips RC-6 mode 0')
-                    ok = True
-
-            if not ok and near(burst[0], 2000) and near(burst[1], 1000):
-                if near(duration, 19000):
-                    print('Microsoft MCE edition protocol.')
-                    # Constant duration, variable burst length, presumably bi-phase
-                    print('Protocol start {} {} Burst length {} duration {}'.format(burst[0], burst[1], lb, duration))
-                    ok = True
-
-            if not ok and near(burst[0], 4500) and near(burst[1], 4500) and lb == 67:  # Samsung
-                print('Samsung')
+        if not ok and near(burst[0], 2666) and near(burst[1], 889):  # RC-6?
+            if near(duration, 22205) and near(burst[1], 889) and near(burst[2], 444):
+                self.protocol = 'RC-6'
+                if self.display: print('Philips RC-6 mode 0')
                 ok = True
 
-            if not ok and near(burst[0], 3500) and near(burst[1], 1680):  # Panasonic?
-                print('Unsupported protocol. Panasonic?')
+        if not ok and near(burst[0], 2000) and near(burst[1], 1000):
+            if near(duration, 19000):
+                self.protocol = 'MCE'
+                if self.display: print('Microsoft MCE edition protocol.')
+                # Constant duration, variable burst length, presumably bi-phase
+                if self.display: print('Protocol start {} {} Burst length {} duration {}'.format(burst[0], burst[1], lb, duration))
                 ok = True
 
-            if not ok:
-                print('Unknown protocol start {} {} Burst length {} duration {}'.format(burst[0], burst[1], lb, duration))
+        if not ok and near(burst[0], 4500) and near(burst[1], 4500) and lb == 67:  # Samsung
+            self.protocol = 'Samsung'
+            if self.display: print('Samsung')
+            ok = True
 
-            print()
+        if not ok and near(burst[0], 3500) and near(burst[1], 1680):  # Panasonic?
+            self.protocol = 'Panasonic'
+            if self.display: print('Unsupported protocol. Panasonic?')
+            ok = True
+
+        if not ok:
+            self.protocol = 'Unknown'
+            if self.display: print('Unknown protocol start {} {} Burst length {} duration {}'.format(burst[0], burst[1], lb, duration))
+        
+        if self.display: print()
         self.data = burst
         # Set up for new data burst. Run null callback
         self.do_callback(0, 0, 0)
@@ -90,7 +98,7 @@ class IR_GET(IR_RX):
         while self.data is None:
             sleep_ms(5)
         self.close()
-        return self.data
+        return {"raw": self.data, "protocol": self.protocol}
 
 def test():
     # Define pin according to platform


### PR DESCRIPTION
I was trying to detect the protocol of an IR command, and found there was no way to properly do it programmatically. So I modified `ir_rx/acquire.py`. The `IR_GET.acquire` function now returns a dict with the keys `raw` and `protocol`. `raw` returns the marks and spaces list as before, and `protocol` returns the protocol detected by `decode()`, or `Unknown`. I also modified `acquire.py` to still try and detect the protocol used, even if `display` is `False`. Setting display to `True` uses print statements _and_ returns the protocol and marks and spaces programmatically, whereas `False` just doesn't print anything.
I also updated the docs for the receiver and transmitter to reflect the changes.

Here is a small test script:
```python
from ir_rx.acquire import IR_GET
from machine import Pin

IR_GET.Timer_id = 0 # For ESP32-C3, although I need to use this on ESP32-S3 for some reason too.
ir_rx = IR_GET(Pin(10, Pin.IN), display=False) # Run without output in terminal
data = ir_rx.acquire()
print("Raw data bursts: " + str(data["raw"]))
print("Protocol: " + data["protocol"])
```

This was only tested on an ESP32-S3, although I doubt further testing on other chip families is needed.

Thank you for this wonderful library, and as this is my first pull request, please let me know if I got something wrong.